### PR TITLE
Reimplemented 'contains' string function.

### DIFF
--- a/olastic-core/src/main/java/com/hevelian/olastic/core/api/uri/queryoption/expression/member/impl/MethodMember.java
+++ b/olastic-core/src/main/java/com/hevelian/olastic/core/api/uri/queryoption/expression/member/impl/MethodMember.java
@@ -1,17 +1,17 @@
 package com.hevelian.olastic.core.api.uri.queryoption.expression.member.impl;
 
-import com.hevelian.olastic.core.api.uri.queryoption.expression.member.ExpressionMember;
-import com.hevelian.olastic.core.elastic.ElasticConstants;
-
 import static com.hevelian.olastic.core.elastic.utils.ElasticUtils.addKeywordIfNeeded;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.prefixQuery;
 import static org.elasticsearch.index.query.QueryBuilders.wildcardQuery;
+
+import com.hevelian.olastic.core.api.uri.queryoption.expression.member.ExpressionMember;
+import com.hevelian.olastic.core.elastic.ElasticConstants;
 
 /**
  * Handles method calls.
  *
  * @author Taras Kohut
+ * @contributor Ruslan Didyk
  */
 public class MethodMember extends BaseMember {
 
@@ -19,7 +19,10 @@ public class MethodMember extends BaseMember {
     public ExpressionResult contains(ExpressionMember left, ExpressionMember right) {
         PrimitiveMember primitive = (PrimitiveMember) left;
         LiteralMember literal = (LiteralMember) right;
-        return new ExpressionResult(matchQuery(primitive.getField(), literal.getValue()));
+        return new ExpressionResult(
+                wildcardQuery(addKeywordIfNeeded(primitive.getField(), primitive.getAnnotations()),
+                        ElasticConstants.WILDCARD_CHAR + literal.getValue()
+                                + ElasticConstants.WILDCARD_CHAR));
     }
 
     @Override

--- a/olastic-core/src/test/java/com/hevelian/olastic/core/api/uri/queryoption/expression/ElasticSearchExpressionVisitorTest.java
+++ b/olastic-core/src/test/java/com/hevelian/olastic/core/api/uri/queryoption/expression/ElasticSearchExpressionVisitorTest.java
@@ -1,11 +1,16 @@
 package com.hevelian.olastic.core.api.uri.queryoption.expression;
 
-import com.hevelian.olastic.core.ElasticOData;
-import com.hevelian.olastic.core.ElasticServiceMetadata;
-import com.hevelian.olastic.core.api.uri.queryoption.expression.member.ExpressionMember;
-import com.hevelian.olastic.core.api.uri.queryoption.expression.member.impl.ExpressionResult;
-import com.hevelian.olastic.core.elastic.mappings.MappingMetaDataProvider;
-import com.hevelian.olastic.core.stub.TestProvider;
+import static com.hevelian.olastic.core.TestUtils.checkFilterEqualsQuery;
+import static com.hevelian.olastic.core.TestUtils.checkFilterNotEqualsQuery;
+import static com.hevelian.olastic.core.TestUtils.checkFilterParentEqualsQuery;
+import static com.hevelian.olastic.core.TestUtils.checkFilterRangeQuery;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+
 import org.apache.olingo.server.api.OData;
 import org.apache.olingo.server.api.ODataApplicationException;
 import org.apache.olingo.server.api.ServiceMetadata;
@@ -19,18 +24,20 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-
-import static com.hevelian.olastic.core.TestUtils.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
+import com.hevelian.olastic.core.ElasticOData;
+import com.hevelian.olastic.core.ElasticServiceMetadata;
+import com.hevelian.olastic.core.api.uri.queryoption.expression.member.ExpressionMember;
+import com.hevelian.olastic.core.api.uri.queryoption.expression.member.impl.ExpressionResult;
+import com.hevelian.olastic.core.elastic.ElasticConstants;
+import com.hevelian.olastic.core.elastic.mappings.MappingMetaDataProvider;
+import com.hevelian.olastic.core.stub.TestProvider;
 
 /**
- * Tests for {@link ElasticSearchExpressionVisitor} class.
- * These tests look more like integration ones, this is required
- * because in order to perform regular unit testing several olingo objects should be created manually, and this is relatively hard.
+ * Tests for {@link ElasticSearchExpressionVisitor} class. These tests look more
+ * like integration ones, this is required because in order to perform regular
+ * unit testing several olingo objects should be created manually, and this is
+ * relatively hard.
+ * 
  * @author Taras Kohut
  */
 public class ElasticSearchExpressionVisitorTest {
@@ -41,12 +48,11 @@ public class ElasticSearchExpressionVisitorTest {
     public void setUp() throws UriParserException, UriValidationException {
         defaultOData = ElasticOData.newInstance();
         defaultMetadata = defaultOData.createServiceMetadata(
-                new TestProvider(mock(MappingMetaDataProvider.class)),
-                new ArrayList<>());
+                new TestProvider(mock(MappingMetaDataProvider.class)), new ArrayList<>());
     }
 
     public static UriInfo buildUriInfo(ServiceMetadata metadata, OData odata, String rawODataPath,
-                                       String rawQueryPath) throws UriParserException, UriValidationException {
+            String rawQueryPath) throws UriParserException, UriValidationException {
         return new Parser(metadata.getEdm(), odata).parseUri(rawODataPath, rawQueryPath, null);
     }
 
@@ -55,8 +61,9 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=age gt 30";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
         checkFilterRangeQuery(query, "gt", "age", "30");
     }
 
@@ -65,8 +72,9 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=age ge 30";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
         checkFilterRangeQuery(query, "ge", "age", "30");
     }
 
@@ -75,8 +83,9 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=age lt 30";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
         checkFilterRangeQuery(query, "lt", "age", "30");
     }
 
@@ -85,8 +94,9 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=age le 30";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
         checkFilterRangeQuery(query, "le", "age", "30");
     }
 
@@ -95,8 +105,9 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=name eq '30'";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
         checkFilterEqualsQuery(query, "name", "'30'");
     }
 
@@ -105,8 +116,9 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=name ne '30'";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
         checkFilterNotEqualsQuery(query, "name", "'30'");
     }
 
@@ -115,21 +127,23 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=name eq '30' and age gt 30";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
 
         JSONObject queryObj = new JSONObject(query);
         JSONObject rootObj = queryObj.getJSONObject("bool");
         JSONArray mustArr = rootObj.getJSONArray("must");
-        JSONObject leftMatchAll = ((JSONObject)mustArr.get(0)).getJSONObject("term");
-        JSONObject rightMatchAll = ((JSONObject)mustArr.get(1)).getJSONObject("range");
+        JSONObject leftMatchAll = ((JSONObject) mustArr.get(0)).getJSONObject("term");
+        JSONObject rightMatchAll = ((JSONObject) mustArr.get(1)).getJSONObject("range");
         assertNotNull(leftMatchAll);
         assertNotNull(rightMatchAll);
     }
 
     @Test(expected = ODataApplicationException.class)
     public void visitBinaryOperator_has_notImplementedException() throws Exception {
-       new ElasticSearchExpressionVisitor().visitBinaryOperator(BinaryOperatorKind.HAS, null, null);
+        new ElasticSearchExpressionVisitor().visitBinaryOperator(BinaryOperatorKind.HAS, null,
+                null);
     }
 
     @Test
@@ -137,14 +151,15 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=name eq '30' or age gt 30";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
 
         JSONObject queryObj = new JSONObject(query);
         JSONObject rootObj = queryObj.getJSONObject("bool");
         JSONArray mustArr = rootObj.getJSONArray("should");
-        JSONObject leftMatchAll = ((JSONObject)mustArr.get(0)).getJSONObject("term");
-        JSONObject rightMatchAll = ((JSONObject)mustArr.get(1)).getJSONObject("range");
+        JSONObject leftMatchAll = ((JSONObject) mustArr.get(0)).getJSONObject("term");
+        JSONObject rightMatchAll = ((JSONObject) mustArr.get(1)).getJSONObject("range");
         assertNotNull(leftMatchAll);
         assertNotNull(rightMatchAll);
     }
@@ -154,13 +169,14 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=not (name eq '30')";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
 
         JSONObject queryObj = new JSONObject(query);
         JSONObject rootObj = queryObj.getJSONObject("bool");
         JSONArray mustArr = rootObj.getJSONArray("must_not");
-        JSONObject matchAllObj = ((JSONObject)mustArr.get(0)).getJSONObject("term");
+        JSONObject matchAllObj = ((JSONObject) mustArr.get(0)).getJSONObject("term");
         assertNotNull(matchAllObj);
     }
 
@@ -169,12 +185,13 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=book/any(b:b/title eq 'name')";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
 
         JSONObject queryObj = new JSONObject(query);
         JSONObject rootObj = queryObj.getJSONObject("has_child");
-        String actualType = (String)rootObj.get("type");
+        String actualType = (String) rootObj.get("type");
         JSONObject queryObject = rootObj.getJSONObject("query");
         JSONObject matchAll = queryObject.getJSONObject("term");
         assertNotNull(matchAll);
@@ -194,12 +211,13 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=_dimension/any(d:d/name eq 'validity')";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
 
         JSONObject queryObj = new JSONObject(query);
         JSONObject rootObj = queryObj.getJSONObject("nested");
-        String actualType = (String)rootObj.get("path");
+        String actualType = (String) rootObj.get("path");
         JSONObject queryObject = rootObj.getJSONObject("query");
         JSONObject term = queryObject.getJSONObject("term");
         JSONObject termValue = term.getJSONObject("_dimension.name");
@@ -207,19 +225,19 @@ public class ElasticSearchExpressionVisitorTest {
         assertEquals("_dimension", actualType);
     }
 
-
     @Test
     public void visitMethodCall_endsWith_CorrectEsQuery() throws Exception {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=endswith(name,'on')";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
 
         JSONObject queryObj = new JSONObject(query);
         JSONObject rootObj = queryObj.getJSONObject("wildcard");
         JSONObject queryObject = rootObj.getJSONObject("name.keyword");
-        String value = (String)queryObject.get("wildcard");
+        String value = (String) queryObject.get("wildcard");
         assertEquals("*on", value);
     }
 
@@ -228,29 +246,31 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=startswith(name,'j')";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
 
         JSONObject queryObj = new JSONObject(query);
         JSONObject rootObj = queryObj.getJSONObject("prefix");
         JSONObject queryObject = rootObj.getJSONObject("name.keyword");
-        String value = (String)queryObject.get("value");
+        String value = (String) queryObject.get("value");
         assertEquals("j", value);
     }
 
     @Test
-     public void visitMethodCall_contains_CorrectEsQuery() throws Exception {
+    public void visitMethodCall_contains_CorrectEsQuery() throws Exception {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=contains(name,'j')";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
 
         JSONObject queryObj = new JSONObject(query);
-        JSONObject rootObj = queryObj.getJSONObject("match");
-        JSONObject queryObject = rootObj.getJSONObject("name");
-        String value = (String)queryObject.get("query");
-        assertEquals("j", value);
+        JSONObject rootObj = queryObj.getJSONObject("wildcard");
+        JSONObject queryObject = rootObj.getJSONObject("name.keyword");
+        String value = (String) queryObject.get("wildcard");
+        assertEquals(ElasticConstants.WILDCARD_CHAR + "j" + ElasticConstants.WILDCARD_CHAR, value);
     }
 
     @Test(expected = ODataApplicationException.class)
@@ -266,13 +286,14 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/author";
         String rawQueryPath = "$filter=date(birthDate) eq 2016-02-14";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
 
         JSONObject queryObj = new JSONObject(query);
         JSONObject rootObj = queryObj.getJSONObject("term");
         JSONObject queryObject = rootObj.getJSONObject("birthDate");
-        String value = (String)queryObject.get("value");
+        String value = (String) queryObject.get("value");
         assertEquals("2016-02-14", value);
     }
 
@@ -281,12 +302,12 @@ public class ElasticSearchExpressionVisitorTest {
         String rawODataPath = "/book";
         String rawQueryPath = "$filter=author/name eq 'Dawkins'";
         UriInfo uriInfo = buildUriInfo(defaultMetadata, defaultOData, rawODataPath, rawQueryPath);
-        ExpressionMember result = uriInfo.getFilterOption().getExpression().accept(new ElasticSearchExpressionVisitor());
-        String query = ((ExpressionResult)result).getQueryBuilder().toString();
+        ExpressionMember result = uriInfo.getFilterOption().getExpression()
+                .accept(new ElasticSearchExpressionVisitor());
+        String query = ((ExpressionResult) result).getQueryBuilder().toString();
 
         checkFilterParentEqualsQuery(query, "author", "name", "'Dawkins'");
     }
-
 
     @Test
     public void visitLambdaExpression_anyExpression_null() throws Exception {

--- a/olastic-core/src/test/java/com/hevelian/olastic/core/api/uri/queryoption/expression/member/impl/MethodMemberTest.java
+++ b/olastic-core/src/test/java/com/hevelian/olastic/core/api/uri/queryoption/expression/member/impl/MethodMemberTest.java
@@ -1,6 +1,8 @@
 package com.hevelian.olastic.core.api.uri.queryoption.expression.member.impl;
 
 import com.hevelian.olastic.core.api.uri.queryoption.expression.member.ExpressionMember;
+import com.hevelian.olastic.core.elastic.ElasticConstants;
+
 import org.apache.olingo.commons.api.edm.EdmAnnotation;
 import org.apache.olingo.commons.api.edm.EdmType;
 import org.apache.olingo.commons.core.edm.primitivetype.EdmString;
@@ -16,6 +18,7 @@ import static org.junit.Assert.*;
 
 /**
  * Tests for {@link MethodMember} class.
+ * 
  * @author Taras Kohut
  */
 public class MethodMemberTest {
@@ -32,11 +35,12 @@ public class MethodMemberTest {
         ExpressionResult result = methodMember.contains(left, right);
 
         JSONObject queryObj = new JSONObject(result.getQueryBuilder().toString());
-        JSONObject rootObj = queryObj.getJSONObject("match");
-        String fieldName = field;
+        JSONObject rootObj = queryObj.getJSONObject("wildcard");
+        String fieldName = field + ".keyword";
         JSONObject valueObject = rootObj.getJSONObject(fieldName);
-        String actualValue = (String)valueObject.get("query");
-        assertEquals(value.substring(1,value.length()-1), actualValue);
+        String actualValue = (String) valueObject.get("wildcard");
+        assertEquals(ElasticConstants.WILDCARD_CHAR + value.substring(1, value.length() - 1)
+                + ElasticConstants.WILDCARD_CHAR, actualValue);
     }
 
     @Test
@@ -50,9 +54,9 @@ public class MethodMemberTest {
         JSONObject rootObj = queryObj.getJSONObject("prefix");
         String fieldName = field + ".keyword";
         JSONObject valueObject = rootObj.getJSONObject(fieldName);
-        String actualValue = (String)valueObject.get("value");
+        String actualValue = (String) valueObject.get("value");
 
-        assertEquals(value.substring(1,value.length()-1), actualValue);
+        assertEquals(value.substring(1, value.length() - 1), actualValue);
     }
 
     @Test
@@ -66,8 +70,8 @@ public class MethodMemberTest {
         JSONObject rootObj = queryObj.getJSONObject("wildcard");
         String fieldName = field + ".keyword";
         JSONObject valueObject = rootObj.getJSONObject(fieldName);
-        String actualValue = (String)valueObject.get("wildcard");
-        assertEquals('*' + value.substring(1,value.length()-1), actualValue);
+        String actualValue = (String) valueObject.get("wildcard");
+        assertEquals('*' + value.substring(1, value.length() - 1), actualValue);
     }
 
     @Test


### PR DESCRIPTION
We used 'match' query for 'contains' function before. For now 'wildcard' query is using.
Performance for 10 million records: first query about 200ms, all after about 70-100ms